### PR TITLE
Additionally key on Rust toolchain file(s) if present

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ This cache is automatically keyed by:
 
 - the github `job`,
 - the rustc release / host / hash, and
-- a hash of the `Cargo.lock` / `Cargo.toml` files.
+- a hash of the `Cargo.lock` / `Cargo.toml` files (if present).
+- a hash of the `rust-toolchain` / `rust-toolchain.toml` files (if present).
 
 An additional input `key` can be provided if the builtin keys are not sufficient.
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -136,7 +136,7 @@ export async function getCmdOutput(
 }
 
 async function getLockfileHash(): Promise<string> {
-  const globber = await glob.create("**/Cargo.toml\n**/Cargo.lock", { followSymbolicLinks: false });
+  const globber = await glob.create("**/Cargo.toml\n**/Cargo.lock\nrust-toolchain\nrust-toolchain.toml", { followSymbolicLinks: false });
   const files = await globber.glob();
   files.sort((a, b) => a.localeCompare(b));
 


### PR DESCRIPTION
These project override files aren't frequently used, but when they are the cache should definitely key on them to catch changes that may not be reflected in `Cargo.toml` alone.

See https://rust-lang.github.io/rustup/overrides.html#the-toolchain-file
