### PR TITLE
hint that checkout has to be done first

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ sensible defaults.
 ## Example usage
 
 ```yaml
+- uses: actions/checkout@v2
+
 # selecting a toolchain either by action or manual `rustup` calls should happen
 # before the plugin, as it uses the current rustc version as its cache key
 - uses: actions-rs/toolchain@v1


### PR DESCRIPTION
Hey @Swatinem, thank you for this awesome project!

Disclaimer: I'm not very experienced either with GitHub actions or rust, so this might be an incorrect change -- feel free to ignore the PR if so.

As far as my experience with this action goes, it does not seem to do anything if the repo gets checked out *after* the cache setup. Placing the `actions/checkout` step before the `rust-cache` step seems to solve the problem though. So

```yml
# no caching
- uses: actions-rs/toolchain@v1
  with:
    profile: minimal
    toolchain: stable
- uses: Swatinem/rust-cache@v1
- uses: actions/checkout@v2 # checkout at the end
```
```yml
# caching works
- uses: actions/checkout@v2 # checkout at the top
- uses: actions-rs/toolchain@v1
  with:
    profile: minimal
    toolchain: stable
- uses: Swatinem/rust-cache@v1
```

It might be a common practice in github actions community to always stick `actions/checkout` at the top of the `yaml` file, but for someone less experienced like me it may seem intuitive to set up caches first, do everything else after - that's what I did, and had to pay for it with a couple of hours of debugging time.

This change adds the checkout step to the readme example explicitly so people like myself who cluelessly copy-paste examples have less things to trip over :)