### PR TITLE
Include env vars in the generated cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ An optional key that is added to the automatic cache key.
 : `sharedKey`
 An additional key that is stable over multiple jobs.
 
+: `envVars`
+A space-separated list of regular expressions that define additional environment variable filters.
+These are added to an additional cache key that's generated from environment variable contents.
+
 : `working-directory`
 The working directory the action operates in, is case the cargo project is not
 located in the repo root.

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
   sharedKey:
     description: "An additional cache key that is stable over multiple jobs"
     required: false
+  envVars:
+    description: "Additional environment variables to include in the cache key, separeted by spaces"
+    required: false
   working-directory:
     description: "The working directory this action should operate in"
     required: false

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59564,6 +59564,7 @@ async function getCacheConfig() {
             key += `${job}-`;
         }
     }
+    key += `${getEnvKey()}-`;
     key += await getRustKey();
     return {
         paths: [
@@ -59593,6 +59594,15 @@ async function getCargoBins() {
     catch {
         return new Set();
     }
+}
+function getEnvKey() {
+    const hasher = external_crypto_default().createHash("sha1");
+    for (const [key, value] of Object.entries(process.env)) {
+        if (value) {
+            hasher.update(`${key}=${value}`);
+        }
+    }
+    return hasher.digest("hex").slice(0, 20);
 }
 async function getRustKey() {
     const rustc = await getRustVersion();

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -59597,8 +59597,19 @@ async function getCargoBins() {
 }
 function getEnvKey() {
     const hasher = external_crypto_default().createHash("sha1");
+    const validKeys = [
+        /^CARGO_.+$/,
+        /^CC_.+$/,
+        /^CXX_.+$/,
+        /^RUSTC_.+$/,
+        /^RUSTC$/,
+        /^RUSTDOC$/,
+        /^RUSTDOCFLAGS$/,
+        /^RUSTFLAGS$/,
+        /^RUSTFMT$/,
+    ];
     for (const [key, value] of Object.entries(process.env)) {
-        if (value) {
+        if (validKeys.some((re) => re.test(key)) && value) {
             hasher.update(`${key}=${value}`);
         }
     }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59564,6 +59564,7 @@ async function getCacheConfig() {
             key += `${job}-`;
         }
     }
+    key += `${getEnvKey()}-`;
     key += await getRustKey();
     return {
         paths: [
@@ -59593,6 +59594,15 @@ async function getCargoBins() {
     catch {
         return new Set();
     }
+}
+function getEnvKey() {
+    const hasher = external_crypto_default().createHash("sha1");
+    for (const [key, value] of Object.entries(process.env)) {
+        if (value) {
+            hasher.update(`${key}=${value}`);
+        }
+    }
+    return hasher.digest("hex").slice(0, 20);
 }
 async function getRustKey() {
     const rustc = await getRustVersion();

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -59597,8 +59597,19 @@ async function getCargoBins() {
 }
 function getEnvKey() {
     const hasher = external_crypto_default().createHash("sha1");
+    const validKeys = [
+        /^CARGO_.+$/,
+        /^CC_.+$/,
+        /^CXX_.+$/,
+        /^RUSTC_.+$/,
+        /^RUSTC$/,
+        /^RUSTDOC$/,
+        /^RUSTDOCFLAGS$/,
+        /^RUSTFLAGS$/,
+        /^RUSTFMT$/,
+    ];
     for (const [key, value] of Object.entries(process.env)) {
-        if (value) {
+        if (validKeys.some((re) => re.test(key)) && value) {
             hasher.update(`${key}=${value}`);
         }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "rust-cache",
       "version": "1.2.0",
       "license": "LGPL-3.0",
       "dependencies": {

--- a/src/common.ts
+++ b/src/common.ts
@@ -71,6 +71,7 @@ export async function getCacheConfig(): Promise<CacheConfig> {
     }
   }
 
+  key += `${getEnvKey()}-`;
   key += await getRustKey();
 
   return {
@@ -103,6 +104,17 @@ export async function getCargoBins(): Promise<Set<string>> {
   } catch {
     return new Set<string>();
   }
+}
+
+function getEnvKey(): string {
+  const hasher = crypto.createHash("sha1");
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value) {
+      hasher.update(`${key}=${value}`);
+    }
+  }
+
+  return hasher.digest("hex").slice(0, 20);
 }
 
 async function getRustKey(): Promise<string> {
@@ -249,5 +261,5 @@ export async function rm(parent: string, dirent: fs.Dirent) {
     } else if (dirent.isDirectory()) {
       await io.rmRF(fileName);
     }
-  } catch {}
+  } catch { }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -108,8 +108,20 @@ export async function getCargoBins(): Promise<Set<string>> {
 
 function getEnvKey(): string {
   const hasher = crypto.createHash("sha1");
+  const validKeys = [
+    /^CARGO_.+$/,
+    /^CC_.+$/,
+    /^CXX_.+$/,
+    /^RUSTC_.+$/,
+    /^RUSTC$/,
+    /^RUSTDOC$/,
+    /^RUSTDOCFLAGS$/,
+    /^RUSTFLAGS$/,
+    /^RUSTFMT$/,
+  ];
+
   for (const [key, value] of Object.entries(process.env)) {
-    if (value) {
+    if (validKeys.some((re) => re.test(key)) && value) {
       hasher.update(`${key}=${value}`);
     }
   }


### PR DESCRIPTION
This PR adds a hash of all available env vars as additional part of the generated cache key as initially suggested in #27.

Right now it simply takes in all env vars available. I think it's good to take in most of them as depending on the Rust project there might be some arbitrary env vars that for example control how external C libraries are built and linked.
That said, there are surely some env vars that are not affecting the compilation in most of situations and should probably be excluded further. The ones I have in mind right now are:
- `HOSTNAME`: Not really important for compilation and different runners should be covered by the `getRustKey` content already. Also, at least in Docker it is a random value, maybe the same in GitHub Actions runners so it might be bad for the cache as well.
- `LS_COLORS`: Color management in the terminal.
- `GITHUB_*`: Basically all the Github Action env vars as they contain job IDs and such, that would render the cache key useless.
- `PWD`: Eventually, depending on projects.
- `TERM`: As the terminal type doesn't affect compilation.
- `TMDIR`: Likely as it's for temp files and may even be a randomly generated folder (at least on MacOS).
- `USER`: As the user doesn't really matter.

There might be others that are specific to GitHub Actions and need to be excluded.
