### PR TITLE
Improve diagnostics: show exception stack trace

### DIFF
--- a/src/restore.ts
+++ b/src/restore.ts
@@ -45,7 +45,7 @@ async function run() {
   } catch (e) {
     setCacheHitOutput(false);
 
-    core.info(`[warning] ${(e as any).message}`);
+    core.info(`[warning] ${(e as any).stack}`);
   }
 }
 

--- a/src/save.ts
+++ b/src/save.ts
@@ -38,26 +38,34 @@ async function run() {
 
     try {
       await cleanRegistry(registryName, packages);
-    } catch {}
+    } catch (e) {
+      core.info(`[warning] ${(e as any).stack}`);
+    }
 
     try {
       await cleanBin();
-    } catch {}
+    } catch (e) {
+      core.info(`[warning] ${(e as any).stack}`);
+    }
 
     try {
       await cleanGit(packages);
-    } catch {}
+    } catch (e) {
+      core.info(`[warning] ${(e as any).stack}`);
+    }
 
     try {
       await cleanTarget(packages);
-    } catch {}
+    } catch (e) {
+      core.info(`[warning] ${(e as any).stack}`);
+    }
 
     core.info(`Saving paths:\n    ${savePaths.join("\n    ")}`);
     core.info(`In directory:\n    ${process.cwd()}`);
     core.info(`Using key:\n    ${key}`);
     await cache.saveCache(savePaths, key);
   } catch (e) {
-    core.info(`[warning] ${(e as any).message}`);
+    core.info(`[warning] ${(e as any).stack}`);
   }
 }
 


### PR DESCRIPTION
Also add logging to the quiet exception handlers.

Before:
![image](https://user-images.githubusercontent.com/302938/175790139-51bf67b1-42e0-4e52-ac0e-95a8d3dea0bc.png)

After:
![image](https://user-images.githubusercontent.com/302938/175790154-b8ed9449-a843-4f77-b497-4f784f7eb933.png)

I also considered adding source maps:
![image](https://user-images.githubusercontent.com/302938/175790168-daac48e0-30f9-42f0-a155-0db59da0ed71.png)
but it increases the size of `dist/` from 5MB to 10MB, and what's worse, source-maps are not diff-friendly, so minor changes will take a lot of space in the repository.
So I decided against that. Navigating non-minified `index.js` is tolerable.

----

I didn't include update to `dist/` in this PR, because I got the impression that you prefer to do it yourself.