### PR TITLE
Put right name for shared key parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ sensible defaults.
     # An explicit cache key that is used instead of the automatic `job`-based
     # cache key and is thus stable across jobs.
     # Default: empty
-    shared-key: ""
+    sharedKey: ""
 
     # An additional cache key that is added alongside the automatic `job`-based
     # cache key and can be used to further differentiate jobs.


### PR DESCRIPTION
In README.md there is a `shared-key` identifier for share key parameter. But action expects `sharedKey`. 