### PR TITLE
Added `prefix-key` `cache-directories` and `cache-targets` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ sensible defaults.
     # Additional non workspace directories, separated by newlines
     cache-directories: ""
 
-    # Determines whether workspace targets are cached
-    # default: "false"
+    # Determines whether workspace `target` directories are cached.
+    # default: "true"
     cache-targets: ""
 
     # Determines if the cache should be saved even when the workflow has failed.

--- a/README.md
+++ b/README.md
@@ -19,8 +19,6 @@ sensible defaults.
     prefix-key: ""
 
     # An additional cache key that is stable over multiple jobs
-    # that is used instead of the automatic `job`-based
-    # cache key and is thus stable across jobs.
     # default: empty
     shared-key: ""
 
@@ -51,7 +49,7 @@ sensible defaults.
     cache-targets: ""
 
     # Determines if the cache should be saved even when the workflow has failed.
-    # Default: "false"
+    # default: "false"
     cache-on-failure: ""
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,29 +14,41 @@ sensible defaults.
 
 - uses: Swatinem/rust-cache@v2
   with:
-    # An explicit cache key that is used instead of the automatic `job`-based
+    # The prefix cache key, this can be changed to start a new cache manually
+    # default: "v0-rust"
+    prefix-key: ""
+
+    # An additional cache key that is stable over multiple jobs
+    # that is used instead of the automatic `job`-based
     # cache key and is thus stable across jobs.
-    # Default: empty
+    # default: empty
     shared-key: ""
 
     # An additional cache key that is added alongside the automatic `job`-based
     # cache key and can be used to further differentiate jobs.
-    # Default: empty
+    # default: empty
     key: ""
 
     # A whitespace separated list of env-var *prefixes* who's value contributes
     # to the environment cache key.
     # The env-vars are matched by *prefix*, so the default `RUST` var will
     # match all of `RUSTC`, `RUSTUP_*`, `RUSTFLAGS`, `RUSTDOC_*`, etc.
-    # Default: "CARGO CC CFLAGS CXX CMAKE RUST"
+    # default: "CARGO CC CFLAGS CXX CMAKE RUST"
     env-vars: ""
 
     # The cargo workspaces and target directory configuration.
     # These entries are separated by newlines and have the form
     # `$workspace -> $target`. The `$target` part is treated as a directory
     # relative to the `$workspace` and defaults to "target" if not explicitly given.
-    # Default: ". -> target"
+    # default: ". -> target"
     workspaces: ""
+
+    # Additional non workspace directories, separated by newlines
+    cache-directories: ""
+
+    # Determines whether workspace targets are cached
+    # default: "false"
+    cache-targets: ""
 
     # Determines if the cache should be saved even when the workflow has failed.
     # Default: "false"

--- a/action.yml
+++ b/action.yml
@@ -2,6 +2,10 @@ name: "Rust Cache"
 description: "A GitHub Action that implements smart caching for rust/cargo projects with sensible defaults."
 author: "Arpad Borsos <swatinem@swatinem.de>"
 inputs:
+  prefix-key:
+    description: "The prefix cache key, this can be changed to start a new cache manually"
+    required: false
+    default: "v0-rust"
   shared-key:
     description: "An additional cache key that is stable over multiple jobs"
     required: false
@@ -14,6 +18,13 @@ inputs:
   workspaces:
     description: "Paths to multiple Cargo workspaces and their target directories, separated by newlines"
     required: false
+  cache-directories:
+    description: "Additional non workspace directories, separated by newlines"
+    required: false
+  cache-targets:
+    description: "Determines whether workspace targets are cached"
+    required: false
+    default: "true"
   cache-on-failure:
     description: "Cache even if the build fails. Defaults to false"
     required: false

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -64545,7 +64545,7 @@ class CacheConfig {
         // Construct key prefix:
         // This uses either the `shared-key` input,
         // or the `key` input combined with the `job` key.
-        let key = `v0-rust`;
+        let key = lib_core.getInput("prefix-key");
         const sharedKey = lib_core.getInput("shared-key");
         if (sharedKey) {
             key += `-${sharedKey}`;
@@ -64630,7 +64630,15 @@ class CacheConfig {
             workspaces.push(new Workspace(root, target));
         }
         self.workspaces = workspaces;
-        self.cachePaths = [config_CARGO_HOME, ...workspaces.map((ws) => ws.target)];
+        self.cachePaths = [config_CARGO_HOME];
+        const cacheTargets = lib_core.getInput("cache-targets").toLowerCase();
+        if (cacheTargets === "true") {
+            self.cachePaths.push(...workspaces.map((ws) => ws.target));
+        }
+        const cacheDirectories = lib_core.getInput("cache-directories");
+        for (const dir of cacheDirectories.trim().split("\n")) {
+            self.cachePaths.push(dir);
+        }
         return self;
     }
     printInfo() {

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -64545,7 +64545,7 @@ class CacheConfig {
         // Construct key prefix:
         // This uses either the `shared-key` input,
         // or the `key` input combined with the `job` key.
-        let key = `v0-rust`;
+        let key = core.getInput("prefix-key");
         const sharedKey = core.getInput("shared-key");
         if (sharedKey) {
             key += `-${sharedKey}`;
@@ -64630,7 +64630,15 @@ class CacheConfig {
             workspaces.push(new Workspace(root, target));
         }
         self.workspaces = workspaces;
-        self.cachePaths = [CARGO_HOME, ...workspaces.map((ws) => ws.target)];
+        self.cachePaths = [CARGO_HOME];
+        const cacheTargets = core.getInput("cache-targets").toLowerCase();
+        if (cacheTargets === "true") {
+            self.cachePaths.push(...workspaces.map((ws) => ws.target));
+        }
+        const cacheDirectories = core.getInput("cache-directories");
+        for (const dir of cacheDirectories.trim().split("\n")) {
+            self.cachePaths.push(dir);
+        }
         return self;
     }
     printInfo() {

--- a/src/config.ts
+++ b/src/config.ts
@@ -50,7 +50,7 @@ export class CacheConfig {
     // This uses either the `shared-key` input,
     // or the `key` input combined with the `job` key.
 
-    let key = `v0-rust`;
+    let key = core.getInput("prefix-key");
 
     const sharedKey = core.getInput("shared-key");
     if (sharedKey) {
@@ -154,7 +154,16 @@ export class CacheConfig {
     }
     self.workspaces = workspaces;
 
-    self.cachePaths = [CARGO_HOME, ...workspaces.map((ws) => ws.target)];
+    self.cachePaths = [CARGO_HOME];
+    const cacheTargets = core.getInput("cache-targets").toLowerCase();
+    if (cacheTargets === "true") {
+      self.cachePaths.push(...workspaces.map((ws) => ws.target));
+    }
+
+    const cacheDirectories = core.getInput("cache-directories");
+    for (const dir of cacheDirectories.trim().split("\n")) {
+      self.cachePaths.push(dir);
+    }
 
     return self;
   }


### PR DESCRIPTION
rust-cache currently stores a target directory even if a shared compilation cache such as  [sccache](github.com/mozilla/sccache) is used.

Added `prefix-key` `cache-directories` and `cache-targets` options allows more control over what compilation artifacts to cache.