### PR TITLE
chore: use linefix to ensure platform line endings

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Compare the expected and actual dist/ directories
         run: |
-          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+          if [ "$(git diff dist/ | wc -l)" -gt "0" ]; then
             echo "Detected uncommitted changes after build. See status below:"
             git diff
             exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@vercel/ncc": "^0.36.1",
-        "lec": "^1.0.1",
+        "linefix": "^0.1.1",
         "typescript": "5.0.4"
       },
       "funding": {
@@ -354,31 +354,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "node_modules/coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
-      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/coffeescript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
-      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
-      "bin": {
-        "cake": "bin/cake",
-        "coffee": "bin/coffee"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -389,11 +364,6 @@
       "engines": {
         "node": ">= 0.8"
       }
-    },
-    "node_modules/commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -445,25 +415,13 @@
         "node": ">=4"
       }
     },
-    "node_modules/lec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lec/-/lec-1.0.1.tgz",
-      "integrity": "sha512-3pIFvYBrdpfMK2cxP4xRBOrM56x1A1SykesXJ1I8/b6sUWvPYhM8p/1jIig0kRrmaKhW9c182GRgNOwwUh3i3A==",
-      "dependencies": {
-        "coffee-script": "^1.10.0",
-        "commander": "^2.8.1",
-        "line-ending-corrector": "^1.0.0"
-      },
+    "node_modules/linefix": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/linefix/-/linefix-0.1.1.tgz",
+      "integrity": "sha512-fHYLcNWUGTs3QjR8GD8tzHmkVbIoTbjcB5MLXs1Iu1cZazTvcUKaCiuarDM0jVygLnpxLTVbbihLJevKARmqrA==",
+      "dev": true,
       "bin": {
-        "lec": "cmd-runner.js"
-      }
-    },
-    "node_modules/line-ending-corrector": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/line-ending-corrector/-/line-ending-corrector-1.0.1.tgz",
-      "integrity": "sha512-uwHj4enSztzPuHdDCysaO94S2bNk8gfR2TKIzPYz2v3sDq/7L6aUxg4uZHnbDYFIdjjxhxcA/2YE7RCqpSbY+A==",
-      "dependencies": {
-        "coffeescript": "^2.0.3"
+        "linefix": "bin/fix.js"
       }
     },
     "node_modules/mime-db": {
@@ -927,16 +885,6 @@
         "concat-map": "0.0.1"
       }
     },
-    "coffee-script": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
-      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
-    },
-    "coffeescript": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
-      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
-    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -944,11 +892,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "2.20.3",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -985,23 +928,11 @@
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw=="
     },
-    "lec": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lec/-/lec-1.0.1.tgz",
-      "integrity": "sha512-3pIFvYBrdpfMK2cxP4xRBOrM56x1A1SykesXJ1I8/b6sUWvPYhM8p/1jIig0kRrmaKhW9c182GRgNOwwUh3i3A==",
-      "requires": {
-        "coffee-script": "^1.10.0",
-        "commander": "^2.8.1",
-        "line-ending-corrector": "^1.0.0"
-      }
-    },
-    "line-ending-corrector": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/line-ending-corrector/-/line-ending-corrector-1.0.1.tgz",
-      "integrity": "sha512-uwHj4enSztzPuHdDCysaO94S2bNk8gfR2TKIzPYz2v3sDq/7L6aUxg4uZHnbDYFIdjjxhxcA/2YE7RCqpSbY+A==",
-      "requires": {
-        "coffeescript": "^2.0.3"
-      }
+    "linefix": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/linefix/-/linefix-0.1.1.tgz",
+      "integrity": "sha512-fHYLcNWUGTs3QjR8GD8tzHmkVbIoTbjcB5MLXs1Iu1cZazTvcUKaCiuarDM0jVygLnpxLTVbbihLJevKARmqrA==",
+      "dev": true
     },
     "mime-db": {
       "version": "1.52.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
       },
       "devDependencies": {
         "@vercel/ncc": "^0.36.1",
+        "lec": "^1.0.1",
         "typescript": "5.0.4"
       },
       "funding": {
@@ -353,6 +354,31 @@
         "concat-map": "0.0.1"
       }
     },
+    "node_modules/coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "deprecated": "CoffeeScript on NPM has moved to \"coffeescript\" (no hyphen)",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/coffeescript": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
+      "bin": {
+        "cake": "bin/cake",
+        "coffee": "bin/coffee"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -363,6 +389,11 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -412,6 +443,27 @@
       "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/lec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lec/-/lec-1.0.1.tgz",
+      "integrity": "sha512-3pIFvYBrdpfMK2cxP4xRBOrM56x1A1SykesXJ1I8/b6sUWvPYhM8p/1jIig0kRrmaKhW9c182GRgNOwwUh3i3A==",
+      "dependencies": {
+        "coffee-script": "^1.10.0",
+        "commander": "^2.8.1",
+        "line-ending-corrector": "^1.0.0"
+      },
+      "bin": {
+        "lec": "cmd-runner.js"
+      }
+    },
+    "node_modules/line-ending-corrector": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/line-ending-corrector/-/line-ending-corrector-1.0.1.tgz",
+      "integrity": "sha512-uwHj4enSztzPuHdDCysaO94S2bNk8gfR2TKIzPYz2v3sDq/7L6aUxg4uZHnbDYFIdjjxhxcA/2YE7RCqpSbY+A==",
+      "dependencies": {
+        "coffeescript": "^2.0.3"
       }
     },
     "node_modules/mime-db": {
@@ -875,6 +927,16 @@
         "concat-map": "0.0.1"
       }
     },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
+    },
+    "coffeescript": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A=="
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -882,6 +944,11 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -917,6 +984,24 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
       "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw=="
+    },
+    "lec": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lec/-/lec-1.0.1.tgz",
+      "integrity": "sha512-3pIFvYBrdpfMK2cxP4xRBOrM56x1A1SykesXJ1I8/b6sUWvPYhM8p/1jIig0kRrmaKhW9c182GRgNOwwUh3i3A==",
+      "requires": {
+        "coffee-script": "^1.10.0",
+        "commander": "^2.8.1",
+        "line-ending-corrector": "^1.0.0"
+      }
+    },
+    "line-ending-corrector": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/line-ending-corrector/-/line-ending-corrector-1.0.1.tgz",
+      "integrity": "sha512-uwHj4enSztzPuHdDCysaO94S2bNk8gfR2TKIzPYz2v3sDq/7L6aUxg4uZHnbDYFIdjjxhxcA/2YE7RCqpSbY+A==",
+      "requires": {
+        "coffeescript": "^2.0.3"
+      }
     },
     "mime-db": {
       "version": "1.52.0",

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "devDependencies": {
     "@vercel/ncc": "^0.36.1",
-    "lec": "^1.0.1",
+    "linefix": "^0.1.1",
     "typescript": "5.0.4"
   },
   "scripts": {
-    "prepare": "ncc build --target es2020 -o dist/restore src/restore.ts && ncc build --target es2020 -o dist/save src/save.ts && lec -v -c LF -d dist"
+    "prepare": "ncc build --target es2020 -o dist/restore src/restore.ts && ncc build --target es2020 -o dist/save src/save.ts && linefix dist"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,9 +30,10 @@
   },
   "devDependencies": {
     "@vercel/ncc": "^0.36.1",
+    "lec": "^1.0.1",
     "typescript": "5.0.4"
   },
   "scripts": {
-    "prepare": "ncc build --target es2020 -o dist/restore src/restore.ts && ncc build --target es2020 -o dist/save src/save.ts"
+    "prepare": "ncc build --target es2020 -o dist/restore src/restore.ts && ncc build --target es2020 -o dist/save src/save.ts && lec -v -c LF -d dist"
   }
 }


### PR DESCRIPTION
Use linefix so that when developing changes the results of `npm run prepare` always have unix line endings so `git diff` commands don't show line ending changes for the `ncc` generated files.