### PR TITLE
feat: add option to cache all crates

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ sensible defaults.
     # default: "false"
     cache-on-failure: ""
 
+    # Determines which crates are cached.
+    # If `true` all crates will be cached, otherwise only dependent crates will be cached.
+    # Useful if additional crates are used for CI tooling.
+    # default: "false"
+    cache-all-crates: ""
+
     # Determiners whether the cache should be saved.
     # If `false`, the cache is only restored.
     # Useful for jobs where the matrix is additive e.g. additional Cargo features.

--- a/action.yml
+++ b/action.yml
@@ -28,6 +28,10 @@ inputs:
   cache-on-failure:
     description: "Cache even if the build fails. Defaults to false."
     required: false
+  cache-all-crates:
+    description: "Determines which crates are cached. If `true` all crates will be cached, otherwise only dependent crates will be cached."
+    required: false
+    default: "false"
   save-if:
     description: "Determiners whether the cache should be saved. If `false`, the cache is only restored."
     required: false

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -60226,7 +60226,7 @@ async function cleanBin() {
         }
     }
 }
-async function cleanRegistry(packages) {
+async function cleanRegistry(packages, crates = true) {
     // `.cargo/registry/src`
     // we can remove this completely, as cargo will recreate this from `cache`
     await rmRF(path.join(CARGO_HOME, "registry", "src"));
@@ -60243,6 +60243,10 @@ async function cleanRegistry(packages) {
             }
             // TODO: else, clean `.cache` based on the `packages`
         }
+    }
+    if (!crates) {
+        core.debug(`skipping crate cleanup`);
+        return;
     }
     const pkgSet = new Set(packages.map((p) => `${p.name}-${p.version}.crate`));
     // `.cargo/registry/cache`

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -85,7 +85,7 @@ export async function cleanBin() {
   }
 }
 
-export async function cleanRegistry(packages: Packages) {
+export async function cleanRegistry(packages: Packages, crates = true) {
   // `.cargo/registry/src`
   // we can remove this completely, as cargo will recreate this from `cache`
   await rmRF(path.join(CARGO_HOME, "registry", "src"));
@@ -104,6 +104,11 @@ export async function cleanRegistry(packages: Packages) {
       }
       // TODO: else, clean `.cache` based on the `packages`
     }
+  }
+
+  if (!crates) {
+    core.debug(`skipping crate cleanup`);
+    return;
   }
 
   const pkgSet = new Set(packages.map((p) => `${p.name}-${p.version}.crate`));

--- a/src/save.ts
+++ b/src/save.ts
@@ -40,35 +40,36 @@ async function run() {
         core.info(`... Cleaning ${workspace.target} ...`);
         await cleanTargetDir(workspace.target, packages);
       } catch (e) {
-        core.info(`[warning] ${(e as any).stack}`);
+        core.error(`${(e as any).stack}`);
       }
     }
 
     try {
-      core.info(`... Cleaning cargo registry ...`);
-      await cleanRegistry(allPackages);
+      const creates = core.getInput("cache-all-crates").toLowerCase() || "false";
+      core.info(`... Cleaning cargo registry cache-all-crates: ${creates} ...`);
+      await cleanRegistry(allPackages, creates === "true");
     } catch (e) {
-      core.info(`[warning] ${(e as any).stack}`);
+      core.error(`${(e as any).stack}`);
     }
 
     try {
       core.info(`... Cleaning cargo/bin ...`);
       await cleanBin();
     } catch (e) {
-      core.info(`[warning] ${(e as any).stack}`);
+      core.error(`${(e as any).stack}`);
     }
 
     try {
       core.info(`... Cleaning cargo git cache ...`);
       await cleanGit(allPackages);
     } catch (e) {
-      core.info(`[warning] ${(e as any).stack}`);
+      core.error(`${(e as any).stack}`);
     }
 
     core.info(`... Saving cache ...`);
     await cache.saveCache(config.cachePaths, config.cacheKey);
   } catch (e) {
-    core.info(`[warning] ${(e as any).stack}`);
+    core.error(`${(e as any).stack}`);
   }
 }
 


### PR DESCRIPTION
Add cache-all-crates option which allows all crates to be cached instead of just the dependency crates. This is useful when additional crates are required for CI tooling.

Fixes #134 