### PR TITLE
fix `src/config.ts`: Remove `sort_object`

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -64224,7 +64224,7 @@ class CacheConfig {
                             }
                         }
                     }
-                    hasher.update(JSON.stringify(sort_object(parsed)));
+                    hasher.update(JSON.stringify(parsed));
                     parsedKeyFiles.push(cargo_manifest);
                 }
                 catch (_e) { // Fallback to caching them as regular file
@@ -64247,7 +64247,7 @@ class CacheConfig {
                     const packages = parsed.package.filter((p) => {
                         "source" in p || "checksum" in p;
                     });
-                    hasher.update(JSON.stringify(sort_object(packages)));
+                    hasher.update(JSON.stringify(packages));
                     parsedKeyFiles.push(cargo_lock);
                 }
                 catch (_e) { // Fallback to caching them as regular file
@@ -64386,23 +64386,6 @@ function sort_and_uniq(a) {
         }
         return accumulator;
     }, []);
-}
-function sort_object(o) {
-    if (Array.isArray(o)) {
-        return o.sort().map(sort_object);
-    }
-    else if (typeof o === 'object' && o != null) {
-        return Object
-            .keys(o)
-            .sort()
-            .reduce(function (a, k) {
-            a[k] = sort_object(o[k]);
-            return a;
-        }, {});
-    }
-    else {
-        return o;
-    }
 }
 
 ;// CONCATENATED MODULE: ./src/cleanup.ts

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -64224,7 +64224,7 @@ class CacheConfig {
                             }
                         }
                     }
-                    hasher.update(JSON.stringify(sort_object(parsed)));
+                    hasher.update(JSON.stringify(parsed));
                     parsedKeyFiles.push(cargo_manifest);
                 }
                 catch (_e) { // Fallback to caching them as regular file
@@ -64247,7 +64247,7 @@ class CacheConfig {
                     const packages = parsed.package.filter((p) => {
                         "source" in p || "checksum" in p;
                     });
-                    hasher.update(JSON.stringify(sort_object(packages)));
+                    hasher.update(JSON.stringify(packages));
                     parsedKeyFiles.push(cargo_lock);
                 }
                 catch (_e) { // Fallback to caching them as regular file
@@ -64386,23 +64386,6 @@ function sort_and_uniq(a) {
         }
         return accumulator;
     }, []);
-}
-function sort_object(o) {
-    if (Array.isArray(o)) {
-        return o.sort().map(sort_object);
-    }
-    else if (typeof o === 'object' && o != null) {
-        return Object
-            .keys(o)
-            .sort()
-            .reduce(function (a, k) {
-            a[k] = sort_object(o[k]);
-            return a;
-        }, {});
-    }
-    else {
-        return o;
-    }
 }
 
 ;// CONCATENATED MODULE: ./src/cleanup.ts

--- a/src/config.ts
+++ b/src/config.ts
@@ -172,7 +172,7 @@ export class CacheConfig {
             }
           }
 
-          hasher.update(JSON.stringify(sort_object(parsed)));
+          hasher.update(JSON.stringify(parsed));
 
           parsedKeyFiles.push(cargo_manifest);
         } catch (_e) { // Fallback to caching them as regular file
@@ -200,7 +200,7 @@ export class CacheConfig {
             "source" in p || "checksum" in p
           });
 
-          hasher.update(JSON.stringify(sort_object(packages)));
+          hasher.update(JSON.stringify(packages));
 
           parsedKeyFiles.push(cargo_lock);
         } catch (_e) { // Fallback to caching them as regular file
@@ -366,21 +366,4 @@ function sort_and_uniq(a: string[]) {
         },
         []
       );
-}
-
-function sort_object(o: any): any {
-  if (Array.isArray(o)) {
-    return o.sort().map(sort_object);
-  } else if (typeof o === 'object' && o != null) {
-    return Object
-      .keys(o)
-      .sort()
-      .reduce(function(a: any, k) {
-        a[k] = sort_object(o[k]);
-  
-        return a;
-      }, {});
-  } else {
-    return o;
-  }
 }


### PR DESCRIPTION
Fixed #151

I've tried running manually load and parse `Cargo.lock` and it runs fine until `sort_object` is called.

Since `Cargo.lock` is auto-generated and usually sorted, I think there is no need for sorting.