### PR TITLE
feat: Add logging to `Cargo.lock`/`Cargo.toml` hashing

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -67029,8 +67029,8 @@ class CacheConfig {
                     hasher.update(JSON.stringify(parsed));
                     parsedKeyFiles.push(cargo_manifest);
                 }
-                catch (_e) {
-                    // Fallback to caching them as regular file
+                catch (e) { // Fallback to caching them as regular file
+                    lib_core.warning(`Error parsing Cargo.toml manifest, fallback to caching entire file: ${e}`);
                     keyFiles.push(cargo_manifest);
                 }
             }
@@ -67042,6 +67042,7 @@ class CacheConfig {
                     if (parsed.version !== 3 || !("package" in parsed)) {
                         // Fallback to caching them as regular file since this action
                         // can only handle Cargo.lock format version 3
+                        lib_core.warning('Unsupported Cargo.lock format, fallback to caching entire file');
                         keyFiles.push(cargo_lock);
                         continue;
                     }
@@ -67053,8 +67054,8 @@ class CacheConfig {
                     hasher.update(JSON.stringify(packages));
                     parsedKeyFiles.push(cargo_lock);
                 }
-                catch (_e) {
-                    // Fallback to caching them as regular file
+                catch (e) { // Fallback to caching them as regular file
+                    lib_core.warning(`Error parsing Cargo.lock manifest, fallback to caching entire file: ${e}`);
                     keyFiles.push(cargo_lock);
                 }
             }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -67029,8 +67029,8 @@ class CacheConfig {
                     hasher.update(JSON.stringify(parsed));
                     parsedKeyFiles.push(cargo_manifest);
                 }
-                catch (_e) {
-                    // Fallback to caching them as regular file
+                catch (e) { // Fallback to caching them as regular file
+                    core.warning(`Error parsing Cargo.toml manifest, fallback to caching entire file: ${e}`);
                     keyFiles.push(cargo_manifest);
                 }
             }
@@ -67042,6 +67042,7 @@ class CacheConfig {
                     if (parsed.version !== 3 || !("package" in parsed)) {
                         // Fallback to caching them as regular file since this action
                         // can only handle Cargo.lock format version 3
+                        core.warning('Unsupported Cargo.lock format, fallback to caching entire file');
                         keyFiles.push(cargo_lock);
                         continue;
                     }
@@ -67053,8 +67054,8 @@ class CacheConfig {
                     hasher.update(JSON.stringify(packages));
                     parsedKeyFiles.push(cargo_lock);
                 }
-                catch (_e) {
-                    // Fallback to caching them as regular file
+                catch (e) { // Fallback to caching them as regular file
+                    core.warning(`Error parsing Cargo.lock manifest, fallback to caching entire file: ${e}`);
                     keyFiles.push(cargo_lock);
                 }
             }

--- a/src/config.ts
+++ b/src/config.ts
@@ -175,8 +175,8 @@ export class CacheConfig {
           hasher.update(JSON.stringify(parsed));
 
           parsedKeyFiles.push(cargo_manifest);
-        } catch (_e) {
-          // Fallback to caching them as regular file
+        } catch (e) { // Fallback to caching them as regular file
+          core.warning(`Error parsing Cargo.toml manifest, fallback to caching entire file: ${e}`);
           keyFiles.push(cargo_manifest);
         }
       }
@@ -191,6 +191,7 @@ export class CacheConfig {
           if (parsed.version !== 3 || !("package" in parsed)) {
             // Fallback to caching them as regular file since this action
             // can only handle Cargo.lock format version 3
+            core.warning('Unsupported Cargo.lock format, fallback to caching entire file');
             keyFiles.push(cargo_lock);
             continue;
           }
@@ -204,8 +205,8 @@ export class CacheConfig {
           hasher.update(JSON.stringify(packages));
 
           parsedKeyFiles.push(cargo_lock);
-        } catch (_e) {
-          // Fallback to caching them as regular file
+        } catch (e) { // Fallback to caching them as regular file
+          core.warning(`Error parsing Cargo.lock manifest, fallback to caching entire file: ${e}`);
           keyFiles.push(cargo_lock);
         }
       }


### PR DESCRIPTION
There are a few problems in cargo-binstall where sometimes change to `Cargo.lock` does not invalidate the cache.