### PR TITLE
Fix typo in hashing parsed `Cargo.lock`

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -67048,9 +67048,7 @@ class CacheConfig {
                     }
                     // Package without `[[package]].source` and `[[package]].checksum`
                     // are the one with `path = "..."` to crates within the workspace.
-                    const packages = parsed.package.filter((p) => {
-                        "source" in p || "checksum" in p;
-                    });
+                    const packages = parsed.package.filter((p) => "source" in p || "checksum" in p);
                     hasher.update(JSON.stringify(packages));
                     parsedKeyFiles.push(cargo_lock);
                 }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -67048,9 +67048,7 @@ class CacheConfig {
                     }
                     // Package without `[[package]].source` and `[[package]].checksum`
                     // are the one with `path = "..."` to crates within the workspace.
-                    const packages = parsed.package.filter((p) => {
-                        "source" in p || "checksum" in p;
-                    });
+                    const packages = parsed.package.filter((p) => "source" in p || "checksum" in p);
                     hasher.update(JSON.stringify(packages));
                     parsedKeyFiles.push(cargo_lock);
                 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -198,9 +198,7 @@ export class CacheConfig {
 
           // Package without `[[package]].source` and `[[package]].checksum`
           // are the one with `path = "..."` to crates within the workspace.
-          const packages = parsed.package.filter((p: any) => {
-            "source" in p || "checksum" in p;
-          });
+          const packages = parsed.package.filter((p: any) => "source" in p || "checksum" in p);
 
           hasher.update(JSON.stringify(packages));
 


### PR DESCRIPTION
This simple mistake caused the entire `Cargo.lock` to be ignored (JS treats having no return as `false`).