### PR TITLE
Fix hashing of parsed `Cargo.toml`

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -67021,8 +67021,16 @@ class CacheConfig {
                         const deps = parsed[section_name];
                         for (const key of Object.keys(deps)) {
                             const dep = deps[key];
-                            if ("path" in dep) {
-                                dep.version = "0.0.0";
+                            try {
+                                if ("path" in dep) {
+                                    dep.version = "0.0.0";
+                                    dep.path = "";
+                                }
+                            }
+                            catch (_e) {
+                                // Not an object, probably a string (version),
+                                // continue.
+                                continue;
                             }
                         }
                     }

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -67021,8 +67021,16 @@ class CacheConfig {
                         const deps = parsed[section_name];
                         for (const key of Object.keys(deps)) {
                             const dep = deps[key];
-                            if ("path" in dep) {
-                                dep.version = "0.0.0";
+                            try {
+                                if ("path" in dep) {
+                                    dep.version = "0.0.0";
+                                    dep.path = "";
+                                }
+                            }
+                            catch (_e) {
+                                // Not an object, probably a string (version),
+                                // continue.
+                                continue;
                             }
                         }
                     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -166,8 +166,15 @@ export class CacheConfig {
             for (const key of Object.keys(deps)) {
               const dep = deps[key];
 
-              if ("path" in dep) {
-                dep.version = "0.0.0";
+              try {
+                if ("path" in dep) {
+                  dep.version = "0.0.0";
+                  dep.path = "";
+                }
+              } catch (_e) {
+                // Not an object, probably a string (version),
+                // continue.
+                continue;
               }
             }
           }


### PR DESCRIPTION
The values for the dependencies could be strings intead of objects, so add a `try` block to take care of that.

Also set `dep.path` to `""` if the dependency contains a key `path` to make sure that the cache isn't invalidated due to change in workspace.