### PR TITLE
Only key by `Cargo.toml` and `Cargo.lock` files of workspace members

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -86960,6 +86960,7 @@ var cache_lib_cache = __nccwpck_require__(7799);
 
 
 
+
 function reportError(e) {
     const { commandFailed } = e;
     if (commandFailed) {
@@ -87006,6 +87007,15 @@ function getCacheProvider() {
         name: cacheProvider,
         cache: cache,
     };
+}
+async function utils_exists(path) {
+    try {
+        await external_fs_default().promises.access(path);
+        return true;
+    }
+    catch {
+        return false;
+    }
 }
 
 ;// CONCATENATED MODULE: ./src/workspace.ts
@@ -87199,10 +87209,8 @@ class CacheConfig {
                     keyFiles.push(cargo_manifest);
                 }
             }
-            const cargo_locks = sort_and_uniq(workspaceMembers
-                .map(member => external_path_default().join(member.path, "Cargo.lock"))
-                .filter((external_fs_default()).existsSync));
-            for (const cargo_lock of cargo_locks) {
+            const cargo_lock = external_path_default().join(workspace.root, "Cargo.lock");
+            if (await utils_exists(cargo_lock)) {
                 try {
                     const content = await promises_default().readFile(cargo_lock, { encoding: "utf8" });
                     const parsed = parse(content);
@@ -87365,6 +87373,7 @@ function sort_and_uniq(a) {
 
 
 
+
 async function cleanTargetDir(targetDir, packages, checkTimestamp = false) {
     lib_core.debug(`cleaning target directory "${targetDir}"`);
     // remove all *files* from the profile directory
@@ -87373,7 +87382,7 @@ async function cleanTargetDir(targetDir, packages, checkTimestamp = false) {
         if (dirent.isDirectory()) {
             let dirName = external_path_default().join(dir.path, dirent.name);
             // is it a profile dir, or a nested target dir?
-            let isNestedTarget = (await exists(external_path_default().join(dirName, "CACHEDIR.TAG"))) || (await exists(external_path_default().join(dirName, ".rustc_info.json")));
+            let isNestedTarget = (await utils_exists(external_path_default().join(dirName, "CACHEDIR.TAG"))) || (await utils_exists(external_path_default().join(dirName, ".rustc_info.json")));
             try {
                 if (isNestedTarget) {
                     await cleanTargetDir(dirName, packages, checkTimestamp);
@@ -87645,15 +87654,6 @@ async function rm(parent, dirent) {
 async function rmRF(dirName) {
     core.debug(`deleting "${dirName}"`);
     await io.rmRF(dirName);
-}
-async function exists(path) {
-    try {
-        await external_fs_default().promises.access(path);
-        return true;
-    }
-    catch {
-        return false;
-    }
 }
 
 ;// CONCATENATED MODULE: ./src/restore.ts

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -87018,24 +87018,29 @@ class Workspace {
         this.root = root;
         this.target = target;
     }
-    async getPackages() {
+    async getPackages(filter, ...extraArgs) {
         let packages = [];
         try {
             core.debug(`collecting metadata for "${this.root}"`);
-            const meta = JSON.parse(await getCmdOutput("cargo", ["metadata", "--all-features", "--format-version", "1"], {
+            const meta = JSON.parse(await getCmdOutput("cargo", ["metadata", "--all-features", "--format-version", "1", ...extraArgs], {
                 cwd: this.root,
             }));
             core.debug(`workspace "${this.root}" has ${meta.packages.length} packages`);
-            for (const pkg of meta.packages) {
-                if (pkg.manifest_path.startsWith(this.root)) {
-                    continue;
-                }
+            for (const pkg of meta.packages.filter(filter)) {
                 const targets = pkg.targets.filter((t) => t.kind.some((kind) => SAVE_TARGETS.has(kind))).map((t) => t.name);
                 packages.push({ name: pkg.name, version: pkg.version, targets, path: external_path_default().dirname(pkg.manifest_path) });
             }
         }
-        catch { }
+        catch (err) {
+            console.error(err);
+        }
         return packages;
+    }
+    async getPackagesOutsideWorkspaceRoot() {
+        return await this.getPackages(pkg => !pkg.manifest_path.startsWith(this.root));
+    }
+    async getWorkspaceMembers() {
+        return await this.getPackages(_ => true, "--no-deps");
     }
 }
 
@@ -87152,7 +87157,8 @@ class CacheConfig {
         for (const workspace of workspaces) {
             const root = workspace.root;
             keyFiles.push(...(await globFiles(`${root}/**/.cargo/config.toml\n${root}/**/rust-toolchain\n${root}/**/rust-toolchain.toml`)));
-            const cargo_manifests = sort_and_uniq(await globFiles(`${root}/**/Cargo.toml`));
+            const workspaceMembers = await workspace.getWorkspaceMembers();
+            const cargo_manifests = sort_and_uniq(workspaceMembers.map(member => external_path_default().join(member.path, "Cargo.toml")));
             for (const cargo_manifest of cargo_manifests) {
                 try {
                     const content = await promises_default().readFile(cargo_manifest, { encoding: "utf8" });
@@ -87193,7 +87199,9 @@ class CacheConfig {
                     keyFiles.push(cargo_manifest);
                 }
             }
-            const cargo_locks = sort_and_uniq(await globFiles(`${root}/**/Cargo.lock`));
+            const cargo_locks = sort_and_uniq(workspaceMembers
+                .map(member => external_path_default().join(member.path, "Cargo.lock"))
+                .filter((external_fs_default()).existsSync));
             for (const cargo_lock of cargo_locks) {
                 try {
                     const content = await promises_default().readFile(cargo_lock, { encoding: "utf8" });
@@ -87678,7 +87686,7 @@ async function run() {
         await macOsWorkaround();
         const allPackages = [];
         for (const workspace of config.workspaces) {
-            const packages = await workspace.getPackages();
+            const packages = await workspace.getPackagesOutsideWorkspaceRoot();
             allPackages.push(...packages);
             try {
                 core.info(`... Cleaning ${workspace.target} ...`);

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -86960,6 +86960,7 @@ var cache_lib_cache = __nccwpck_require__(7799);
 
 
 
+
 function reportError(e) {
     const { commandFailed } = e;
     if (commandFailed) {
@@ -87006,6 +87007,15 @@ function getCacheProvider() {
         name: cacheProvider,
         cache: cache,
     };
+}
+async function exists(path) {
+    try {
+        await external_fs_default().promises.access(path);
+        return true;
+    }
+    catch {
+        return false;
+    }
 }
 
 ;// CONCATENATED MODULE: ./src/workspace.ts
@@ -87199,10 +87209,8 @@ class CacheConfig {
                     keyFiles.push(cargo_manifest);
                 }
             }
-            const cargo_locks = sort_and_uniq(workspaceMembers
-                .map(member => external_path_default().join(member.path, "Cargo.lock"))
-                .filter((external_fs_default()).existsSync));
-            for (const cargo_lock of cargo_locks) {
+            const cargo_lock = external_path_default().join(workspace.root, "Cargo.lock");
+            if (await exists(cargo_lock)) {
                 try {
                     const content = await promises_default().readFile(cargo_lock, { encoding: "utf8" });
                     const parsed = parse(content);
@@ -87360,6 +87368,7 @@ function sort_and_uniq(a) {
 }
 
 ;// CONCATENATED MODULE: ./src/cleanup.ts
+
 
 
 
@@ -87645,15 +87654,6 @@ async function rm(parent, dirent) {
 async function rmRF(dirName) {
     core.debug(`deleting "${dirName}"`);
     await io.rmRF(dirName);
-}
-async function exists(path) {
-    try {
-        await external_fs_default().promises.access(path);
-        return true;
-    }
-    catch {
-        return false;
-    }
 }
 
 ;// CONCATENATED MODULE: ./src/save.ts

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -4,6 +4,7 @@ import fs from "fs";
 import path from "path";
 
 import { CARGO_HOME } from "./config";
+import { exists } from "./utils";
 import { Packages } from "./workspace";
 
 export async function cleanTargetDir(targetDir: string, packages: Packages, checkTimestamp = false) {
@@ -307,13 +308,4 @@ async function rm(parent: string, dirent: fs.Dirent) {
 async function rmRF(dirName: string) {
   core.debug(`deleting "${dirName}"`);
   await io.rmRF(dirName);
-}
-
-async function exists(path: string) {
-  try {
-    await fs.promises.access(path);
-    return true;
-  } catch {
-    return false;
-  }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,7 +8,7 @@ import path from "path";
 import * as toml from "smol-toml";
 
 import { getCargoBins } from "./cleanup";
-import { CacheProvider, getCmdOutput } from "./utils";
+import { CacheProvider, exists, getCmdOutput } from "./utils";
 import { Workspace } from "./workspace";
 
 const HOME = os.homedir();
@@ -191,12 +191,8 @@ export class CacheConfig {
         }
       }
 
-      const cargo_locks = sort_and_uniq(workspaceMembers
-        .map(member => path.join(member.path, "Cargo.lock"))
-        .filter(fs.existsSync)
-      );
-
-      for (const cargo_lock of cargo_locks) {
+      const cargo_lock = path.join(workspace.root, "Cargo.lock");
+      if (await exists(cargo_lock)) {
         try {
           const content = await fs_promises.readFile(cargo_lock, { encoding: "utf8" });
           const parsed = toml.parse(content);

--- a/src/config.ts
+++ b/src/config.ts
@@ -142,7 +142,9 @@ export class CacheConfig {
         )),
       );
 
-      const cargo_manifests = sort_and_uniq(await globFiles(`${root}/**/Cargo.toml`));
+      const workspaceMembers = await workspace.getWorkspaceMembers();
+
+      const cargo_manifests = sort_and_uniq(workspaceMembers.map(member => path.join(member.path, "Cargo.toml")));
 
       for (const cargo_manifest of cargo_manifests) {
         try {
@@ -189,7 +191,10 @@ export class CacheConfig {
         }
       }
 
-      const cargo_locks = sort_and_uniq(await globFiles(`${root}/**/Cargo.lock`));
+      const cargo_locks = sort_and_uniq(workspaceMembers
+        .map(member => path.join(member.path, "Cargo.lock"))
+        .filter(fs.existsSync)
+      );
 
       for (const cargo_lock of cargo_locks) {
         try {

--- a/src/save.ts
+++ b/src/save.ts
@@ -36,7 +36,7 @@ async function run() {
 
     const allPackages = [];
     for (const workspace of config.workspaces) {
-      const packages = await workspace.getPackages();
+      const packages = await workspace.getPackagesOutsideWorkspaceRoot();
       allPackages.push(...packages);
       try {
         core.info(`... Cleaning ${workspace.target} ...`);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import * as core from "@actions/core";
 import * as exec from "@actions/exec";
 import * as buildjetCache from "@actions/buildjet-cache";
 import * as ghCache from "@actions/cache";
+import fs from "fs";
 
 export function reportError(e: any) {
   const { commandFailed } = e;
@@ -60,4 +61,13 @@ export function getCacheProvider(): CacheProvider {
     name: cacheProvider,
     cache: cache,
   };
+}
+
+export async function exists(path: string) {
+  try {
+    await fs.promises.access(path);
+    return true;
+  } catch {
+    return false;
+  }
 }


### PR DESCRIPTION
Currently, we glob for all `Cargo.toml` and `Cargo.lock` files anywhere in a workspace, but this can pick up false positives (see #179). This PR switches to only using `Cargo.toml` files of workspace members (determined using [`cargo metadata --no-deps`](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html#output-options)) and per-workspace `Cargo.lock` files.

Closes #179