### PR TITLE
Upgrade checkout action from version 3 to 4

### DIFF
--- a/.github/workflows/buildjet.yml
+++ b/.github/workflows/buildjet.yml
@@ -16,7 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -15,7 +15,7 @@ jobs:
   check-dist:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v3

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -16,7 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
 

--- a/.github/workflows/git-registry.yml
+++ b/.github/workflows/git-registry.yml
@@ -17,7 +17,7 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -16,7 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -16,7 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/target-dir.yml
+++ b/.github/workflows/target-dir.yml
@@ -16,7 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/workspaces.yml
+++ b/.github/workflows/workspaces.yml
@@ -16,7 +16,7 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown --no-self-update
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ sensible defaults.
 ## Example usage
 
 ```yaml
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 
 # selecting a toolchain either by action or manual `rustup` calls should happen
 # before the plugin, as the cache uses the current rustc version as its cache key


### PR DESCRIPTION
This fixes issue #189.

This is necessary because GitHub actions are going to drop support for Node.js 16. Version 4 uses Node.js 20.

See https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/