### PR TITLE
Only run macOsWorkaround() on macOS

### DIFF
--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -88832,7 +88832,9 @@ async function run() {
         config.printInfo(cacheProvider);
         core.info("");
         // TODO: remove this once https://github.com/actions/toolkit/pull/553 lands
-        await macOsWorkaround();
+        if (process.env["RUNNER_OS"] == "macOS") {
+            await macOsWorkaround();
+        }
         const allPackages = [];
         for (const workspace of config.workspaces) {
             const packages = await workspace.getPackagesOutsideWorkspaceRoot();

--- a/src/save.ts
+++ b/src/save.ts
@@ -32,7 +32,9 @@ async function run() {
     core.info("");
 
     // TODO: remove this once https://github.com/actions/toolkit/pull/553 lands
-    await macOsWorkaround();
+    if (process.env["RUNNER_OS"] == "macOS") {
+      await macOsWorkaround();
+    }
 
     const allPackages = [];
     for (const workspace of config.workspaces) {


### PR DESCRIPTION
Currently, when you run a workflow using ubuntu-latest and this action through [nektos/act](https://github.com/nektos/act), it will hang during the save process due to `sudo` awaiting user input because `/usr/sbin/purge` isn't found (meaning you'll have to exec into the container and kill this sudo process to make it move on).

This change makes it only try to run purge if you're actually on a macOS runner.