### PR TITLE
Adds an option to do lookup-only of the cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ sensible defaults.
     # default: "false"
     cache-all-crates: ""
 
-    # Determiners whether the cache should be saved.
+    # Determines whether the cache should be saved.
     # If `false`, the cache is only restored.
     # Useful for jobs where the matrix is additive e.g. additional Cargo features,
     # or when only runs from `master` should be saved to the cache.
@@ -68,6 +68,12 @@ sensible defaults.
     save-if: ""
     # To only cache runs from `master`:
     save-if: ${{ github.ref == 'refs/heads/master' }}
+
+    # Determines whether the cache should be restored.
+    # If `true` the cache key will be checked and the `cache-hit` output will be set
+    # but the cache itself won't be restored
+    # default: "false"
+    lookup-only: ""
 
     # Specifies what to use as the backend providing cache
     # Can be set to either "github" or "buildjet"

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,10 @@ inputs:
     description: "Determines which provider to use for caching. Options are github or buildjet, defaults to github."
     required: false
     default: "github"
+  lookup-only:
+    description: "Check if a cache entry exists without downloading the cache"
+    required: false
+    default: "false"
 outputs:
   cache-hit:
     description: "A boolean value that indicates an exact match was found."

--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -77876,20 +77876,21 @@ async function run() {
         if (cacheOnFailure !== "true") {
             cacheOnFailure = "false";
         }
+        var lookupOnly = lib_core.getInput("lookup-only").toLowerCase() === "true";
         lib_core.exportVariable("CACHE_ON_FAILURE", cacheOnFailure);
         lib_core.exportVariable("CARGO_INCREMENTAL", 0);
         const config = await CacheConfig.new();
         config.printInfo(cacheProvider);
         lib_core.info("");
-        lib_core.info(`... Restoring cache ...`);
+        lib_core.info(`... ${lookupOnly ? "Checking" : "Restoring"} cache ...`);
         const key = config.cacheKey;
         // Pass a copy of cachePaths to avoid mutating the original array as reported by:
         // https://github.com/actions/toolkit/pull/1378
         // TODO: remove this once the underlying bug is fixed.
-        const restoreKey = await cacheProvider.cache.restoreCache(config.cachePaths.slice(), key, [config.restoreKey]);
+        const restoreKey = await cacheProvider.cache.restoreCache(config.cachePaths.slice(), key, [config.restoreKey], { lookupOnly });
         if (restoreKey) {
             const match = restoreKey === key;
-            lib_core.info(`Restored from cache key "${restoreKey}" full match: ${match}.`);
+            lib_core.info(`${lookupOnly ? "Found" : "Restored from"} cache key "${restoreKey}" full match: ${match}.`);
             if (!match) {
                 // pre-clean the target directory on cache mismatch
                 for (const workspace of config.workspaces) {

--- a/src/restore.ts
+++ b/src/restore.ts
@@ -24,6 +24,8 @@ async function run() {
     if (cacheOnFailure !== "true") {
       cacheOnFailure = "false";
     }
+    var lookupOnly = core.getInput("lookup-only").toLowerCase() === "true";
+
     core.exportVariable("CACHE_ON_FAILURE", cacheOnFailure);
     core.exportVariable("CARGO_INCREMENTAL", 0);
 
@@ -31,15 +33,24 @@ async function run() {
     config.printInfo(cacheProvider);
     core.info("");
 
-    core.info(`... Restoring cache ...`);
+    core.info(`... ${lookupOnly ? "Checking" : "Restoring"} cache ...`);
     const key = config.cacheKey;
     // Pass a copy of cachePaths to avoid mutating the original array as reported by:
     // https://github.com/actions/toolkit/pull/1378
     // TODO: remove this once the underlying bug is fixed.
-    const restoreKey = await cacheProvider.cache.restoreCache(config.cachePaths.slice(), key, [config.restoreKey]);
+    const restoreKey = await cacheProvider.cache.restoreCache(
+      config.cachePaths.slice(),
+      key,
+      [config.restoreKey],
+      { lookupOnly }
+    );
     if (restoreKey) {
       const match = restoreKey === key;
-      core.info(`Restored from cache key "${restoreKey}" full match: ${match}.`);
+      core.info(
+        `${
+          lookupOnly ? "Found" : "Restored from"
+        } cache key "${restoreKey}" full match: ${match}.`
+      );
       if (!match) {
         // pre-clean the target directory on cache mismatch
         for (const workspace of config.workspaces) {


### PR DESCRIPTION
This option is sent through to the underlying `actions/cache` and can be helpful (in conjunction with `save-if`) for cases where you only want to check if the cache exists.