### PR TITLE
Enable incremental caching for faster builds

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: "Check if a cache entry exists without downloading the cache"
     required: false
     default: "false"
+  incremental:
+    description: "Determines whether to cache incremental builds - speeding up builds for more disk usage. Defaults to false."
+    required: false
+    default: "false"
 outputs:
   cache-hit:
     description: "A boolean value that indicates an exact match was found."

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,6 +34,9 @@ export class CacheConfig {
   /** The cargo binaries present during main step */
   public cargoBins: Array<string> = [];
 
+  /** Whether to cache incremental builds */
+  public incremental: boolean = false;
+
   /** The prefix portion of the cache key */
   private keyPrefix = "";
   /** The rust version considered for the cache key */
@@ -43,7 +46,7 @@ export class CacheConfig {
   /** The files considered for the cache key */
   private keyFiles: Array<string> = [];
 
-  private constructor() {}
+  private constructor() { }
 
   /**
    * Constructs a [`CacheConfig`] with all the paths and keys.

--- a/src/incremental.ts
+++ b/src/incremental.ts
@@ -1,0 +1,48 @@
+import * as core from "@actions/core";
+import * as io from "@actions/io";
+import fs from "fs";
+import path from "path";
+
+import { CARGO_HOME } from "./config";
+import { exists } from "./utils";
+import { Packages } from "./workspace";
+
+
+export async function restoreIncremental(targetDir: string) {
+  core.debug(`restoring incremental directory "${targetDir}"`);
+
+
+  let dir = await fs.promises.opendir(targetDir);
+  for await (const dirent of dir) {
+    if (dirent.isDirectory()) {
+      let dirName = path.join(dir.path, dirent.name);
+      // is it a profile dir, or a nested target dir?
+      let isNestedTarget =
+        (await exists(path.join(dirName, "CACHEDIR.TAG"))) || (await exists(path.join(dirName, ".rustc_info.json")));
+
+      try {
+        if (isNestedTarget) {
+          await restoreIncremental(dirName);
+        } else {
+          await restoreIncrementalProfile(dirName);
+        } restoreIncrementalProfile
+      } catch { }
+    }
+  }
+}
+
+async function restoreIncrementalProfile(dirName: string) {
+  core.debug(`restoring incremental profile directory "${dirName}"`);
+  const incrementalJson = path.join(dirName, "incremental-restore.json");
+  if (await exists(incrementalJson)) {
+    const contents = await fs.promises.readFile(incrementalJson, "utf8");
+    const { modifiedTimes } = JSON.parse(contents);
+
+    // Write the mtimes to all the files in the profile directory
+    for (const fileName of Object.keys(modifiedTimes)) {
+      const mtime = modifiedTimes[fileName];
+      const filePath = path.join(dirName, fileName);
+      await fs.promises.utimes(filePath, new Date(mtime), new Date(mtime));
+    }
+  }
+}

--- a/src/save.ts
+++ b/src/save.ts
@@ -42,7 +42,7 @@ async function run() {
       allPackages.push(...packages);
       try {
         core.info(`... Cleaning ${workspace.target} ...`);
-        await cleanTargetDir(workspace.target, packages);
+        await cleanTargetDir(workspace.target, packages, false, config.incremental);
       } catch (e) {
         core.debug(`${(e as any).stack}`);
       }
@@ -90,5 +90,5 @@ async function macOsWorkaround() {
     // Workaround for https://github.com/actions/cache/issues/403
     // Also see https://github.com/rust-lang/cargo/issues/8603
     await exec.exec("sudo", ["/usr/sbin/purge"], { silent: true });
-  } catch {}
+  } catch { }
 }


### PR DESCRIPTION
Dioxus has a pretty huge mono-repo and incremental builds would significantly help speed our CI times up.

This PR implements the strategy ideated in #43 that saves and restores the mtimes for the incremental directory per profile, allowing rustc to re-use the incremental objects.

I have yet to implement a sweep-type solution here, but it seems that cargo does some cleaning of the incremental dir itself so the size shouldn't grow out of control.

I wouldn't merge this until we have a sweep-type solution, but I'm opening this to be able to run tests against the dioxus doc site and mono-repo.