### PR TITLE
Include CPU arch in the cache key for arm64 Linux runners

### DIFF
--- a/dist/restore/index.js
+++ b/dist/restore/index.js
@@ -86755,9 +86755,10 @@ class CacheConfig {
                 key += `-${job}`;
             }
         }
-        // Add runner OS to the key to avoid cross-contamination of cache
+        // Add runner OS and CPU architecture to the key to avoid cross-contamination of cache
         const runnerOS = external_os_default().type();
-        key += `-${runnerOS}`;
+        const runnerArch = external_os_default().arch();
+        key += `-${runnerOS}-${runnerArch}`;
         self.keyPrefix = key;
         // Construct environment portion of the key:
         // This consists of a hash that considers the rust version

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -86755,9 +86755,10 @@ class CacheConfig {
                 key += `-${job}`;
             }
         }
-        // Add runner OS to the key to avoid cross-contamination of cache
+        // Add runner OS and CPU architecture to the key to avoid cross-contamination of cache
         const runnerOS = external_os_default().type();
-        key += `-${runnerOS}`;
+        const runnerArch = external_os_default().arch();
+        key += `-${runnerOS}-${runnerArch}`;
         self.keyPrefix = key;
         // Construct environment portion of the key:
         // This consists of a hash that considers the rust version

--- a/src/config.ts
+++ b/src/config.ts
@@ -74,9 +74,10 @@ export class CacheConfig {
       }
     }
 
-    // Add runner OS to the key to avoid cross-contamination of cache
+    // Add runner OS and CPU architecture to the key to avoid cross-contamination of cache
     const runnerOS = os.type();
-    key += `-${runnerOS}`;
+    const runnerArch = os.arch();
+    key += `-${runnerOS}-${runnerArch}`;
 
     self.keyPrefix = key;
 


### PR DESCRIPTION
GitHub [announced](https://github.blog/changelog/2024-06-24-github-actions-ubuntu-24-04-image-now-available-for-arm64-runners/) Linux arm64 hosted runners.

Now GitHub Actions supports both x86_64 and arm64 for Linux. However rust-cache action doesn't include the CPU arch in the cache key. For example:

```
v0-rust-unit-test-Linux-ec67c29d-227d31a8
```

This PR includes CPU arch in the generated cache key so that it can ensure different caches are created on different CPU architectures and they are not mixed up.