### PR TITLE
Add cache-workspace-crates feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,12 @@ sensible defaults.
     # default: "false"
     cache-all-crates: ""
 
+    # Similar to cache-all-crates.
+    # If `true` the workspace crates will be cached.
+    # Useful if the workspace contains libraries that are only updated sporadically.
+    # default: "false"
+    cache-workspace-crates: ""
+
     # Determines whether the cache should be saved.
     # If `false`, the cache is only restored.
     # Useful for jobs where the matrix is additive e.g. additional Cargo features,

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: "Determines which crates are cached. If `true` all crates will be cached, otherwise only dependent crates will be cached."
     required: false
     default: "false"
+  cache-workspace-crates:
+    description: "Similar to cache-all-crates. If `true` the workspace crates will be cached."
+    required: false
+    default: "false"
   save-if:
     description: "Determiners whether the cache should be saved. If `false`, the cache is only restored."
     required: false

--- a/dist/save/index.js
+++ b/dist/save/index.js
@@ -87340,9 +87340,14 @@ async function run() {
         if (process.env["RUNNER_OS"] == "macOS") {
             await macOsWorkaround();
         }
+        const workspaceCrates = core.getInput("cache-workspace-crates").toLowerCase() || "false";
         const allPackages = [];
         for (const workspace of config.workspaces) {
             const packages = await workspace.getPackagesOutsideWorkspaceRoot();
+            if (workspaceCrates === "true") {
+                const wsMembers = await workspace.getWorkspaceMembers();
+                packages.push(...wsMembers);
+            }
             allPackages.push(...packages);
             try {
                 core.info(`... Cleaning ${workspace.target} ...`);

--- a/src/save.ts
+++ b/src/save.ts
@@ -36,9 +36,14 @@ async function run() {
       await macOsWorkaround();
     }
 
+    const workspaceCrates = core.getInput("cache-workspace-crates").toLowerCase() || "false";
     const allPackages = [];
     for (const workspace of config.workspaces) {
       const packages = await workspace.getPackagesOutsideWorkspaceRoot();
+      if (workspaceCrates === "true") {
+        const wsMembers = await workspace.getWorkspaceMembers();
+        packages.push(...wsMembers);
+      }
       allPackages.push(...packages);
       try {
         core.info(`... Cleaning ${workspace.target} ...`);


### PR DESCRIPTION
The default caching strategy is to exclude workspace crates, which makes sense for small workspaces, but in cases where the workspace contains libraries which are hardly changed it is nicer to cache the workspace creates as well. This PR adds that option.

Note that setting `cache-all-crates = true` makes `cache-workspace-crates` irrelevant, in principle there are only three options now (only dependencies, dependencies+workspace, all), but to keep things backwards compatible I did not want to change the existing options, so I think adding this should be fine.