### PR TITLE
ci: address lint findings, add zizmor workflow

### DIFF
--- a/.github/workflows/buildjet.yml
+++ b/.github/workflows/buildjet.yml
@@ -2,6 +2,8 @@ name: buildjet
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   buildjet:
     if: github.repository == 'Swatinem/rust-cache'
@@ -17,7 +19,9 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -11,15 +11,19 @@ on:
       - "**.md"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   check-dist:
     if: github.repository == 'Swatinem/rust-cache'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20.x
           cache: npm
@@ -39,7 +43,7 @@ jobs:
           fi
         id: diff
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,6 +2,8 @@ name: coverage
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   coverage:
     if: github.repository == 'Swatinem/rust-cache'
@@ -17,11 +19,15 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - run: rustup toolchain install stable --profile minimal --component llvm-tools-preview --no-self-update
 
-      - uses: taiki-e/install-action@cargo-llvm-cov
+      - uses: taiki-e/install-action@cd39cb0572834c149bf3533a143f05e09def0f3c # v2.62.2
+        with:
+          tool: cargo-llvm-cov
 
       - uses: ./
         with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 2
-          persist-credentials: true
+          persist-credentials: false
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
       - name: Check if package-lock.json has been changed
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -3,23 +3,25 @@
 name: Dependabot Automation
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # for pushing commits
+      pull-requests: write # for merging PRs
     if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'Swatinem/rust-cache'
     steps:
       - name: Fetch metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@08eff52bf64351f401fb50d4972fa95b9f2c2d1b # v2.4.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: actions/checkout@v5
-        with: 
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
           fetch-depth: 2
+          persist-credentials: true
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
       - name: Check if package-lock.json has been changed
         if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
@@ -35,7 +37,7 @@ jobs:
           fi
       - name: Setup node if necessary
         if: steps.npm.outputs.changed != ''
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 20.x
           cache: npm

--- a/.github/workflows/git-registry.yml
+++ b/.github/workflows/git-registry.yml
@@ -2,6 +2,8 @@ name: git-registry
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   git-registry:
     if: github.repository == 'Swatinem/rust-cache'
@@ -18,7 +20,9 @@ jobs:
       CARGO_REGISTRIES_CRATES_IO_PROTOCOL: git
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,6 +2,8 @@ name: install
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   install:
     if: github.repository == 'Swatinem/rust-cache'
@@ -17,7 +19,9 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/simple.yml
+++ b/.github/workflows/simple.yml
@@ -2,6 +2,8 @@ name: simple
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   simple:
     if: github.repository == 'Swatinem/rust-cache'
@@ -17,7 +19,9 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/target-dir.yml
+++ b/.github/workflows/target-dir.yml
@@ -2,6 +2,8 @@ name: target-dir
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   target-dir:
     if: github.repository == 'Swatinem/rust-cache'
@@ -17,7 +19,9 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - run: rustup toolchain install stable --profile minimal --no-self-update
 

--- a/.github/workflows/workspaces.yml
+++ b/.github/workflows/workspaces.yml
@@ -2,6 +2,8 @@ name: workspaces
 
 on: [push, pull_request]
 
+permissions: {}
+
 jobs:
   workspaces:
     if: github.repository == 'Swatinem/rust-cache'
@@ -17,7 +19,9 @@ jobs:
       CARGO_TERM_COLOR: always
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - run: rustup toolchain install stable --profile minimal --target wasm32-unknown-unknown --no-self-update
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: GitHub Actions Security Analysis with zizmor 🌈
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor 🌈
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # for uploading results to the Security tab
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor 🌈
+        uses: zizmorcore/zizmor-action@e673c3917a1aef3c65c972347ed84ccd013ecda4 # v0.2.0


### PR DESCRIPTION
Hi there!

First, I wanted to say thanks for creating and maintaining this action -- I use it both personally and professionally, and it's been a joy to use.

I'm filling this with a bunch of (small) security fixes, all of which were identified by [zizmor](https://docs.zizmor.sh), which I maintain. None of the findings were particularly severe or immediately exploitable, which is why I'm filing it without a private disclosure -- I think these would all be good to fix as a matter of defense-in-depth, but there's no significant urgency to them 🙂 

To summarize:

1. I've hash-pinned all of the current `uses:` -- this makes the CI more hermetic, and makes it less likely that a security or reliability issue gets introduced in via a tag mutation.
2. I've added `persist-credentials: false` to as many `actions/checkout` usages as possible -- this eliminates an implicitly persisted credential that GitHub Actions adds by default, which the overwhelming majority of workflows don't need.
3. I've added a `zizmor.yml` workflow that'll run zizmor on every PR and push; it's integrated into GitHub's "Advanced Security" so that you'll get alerts on PRs that introduce potential issues. However, this is only if you *want* continuous scanning here; if you'd prefer to not have another thing in your CI, I'm happy to remove this step!
