### PR TITLE
Don't overwrite env for cargo-metadata call

### DIFF
--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -15,7 +15,7 @@ export class Workspace {
       const meta: Meta = JSON.parse(
         await getCmdOutput("cargo", ["metadata", "--all-features", "--format-version", "1", ...extraArgs], {
           cwd: this.root,
-          env: { "CARGO_ENCODED_RUSTFLAGS": "" },
+          env: { ...process.env, "CARGO_ENCODED_RUSTFLAGS": "" },
         }),
       );
       core.debug(`workspace "${this.root}" has ${meta.packages.length} packages`);


### PR DESCRIPTION
In some cases(eg. if RUST_TOOLCHAIN is set and cargo is managed by rustup) cargo metadata will behave
incorrectly if some environment variables are removed

Resolves https://github.com/Swatinem/rust-cache/issues/264