### PR TITLE
Scan content of `$CARGO_HOME/bin` on restore instead of relying on `cargo install` metadata 

### DIFF
--- a/.github/workflows/binstall.yml
+++ b/.github/workflows/binstall.yml
@@ -1,0 +1,34 @@
+name: binstall
+
+on: [push, pull_request]
+
+permissions: {}
+
+jobs:
+  binstall:
+    if: github.repository == 'Swatinem/rust-cache'
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    name: Test `cargo binstall` on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CARGO_TERM_COLOR: always
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - run: rustup toolchain install stable --profile minimal --no-self-update
+
+      - uses: cargo-bins/cargo-binstall@v1.17.9
+
+      - uses: ./
+
+      - run: cargo binstall -y cargo-deny
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/src/cleanup.ts
+++ b/src/cleanup.ts
@@ -77,16 +77,16 @@ async function cleanProfileTarget(profileDir: string, packages: Packages, checkT
 
 export async function getCargoBins(): Promise<Set<string>> {
   const bins = new Set<string>();
+
   try {
-    const { installs }: { installs: { [key: string]: { bins: Array<string> } } } = JSON.parse(
-      await fs.promises.readFile(path.join(CARGO_HOME, ".crates2.json"), "utf8"),
-    );
-    for (const pkg of Object.values(installs)) {
-      for (const bin of pkg.bins) {
-        bins.add(bin);
+    const dir = await fs.promises.opendir(path.join(CARGO_HOME, "bin"));
+    for await (const dirent of dir) {
+      if (dirent.isFile()) {
+        bins.add(dirent.name);
       }
     }
   } catch {}
+
   return bins;
 }
 
@@ -97,15 +97,11 @@ export async function getCargoBins(): Promise<Set<string>> {
  * @param oldBins The binaries that existed when the action started.
  */
 export async function cleanBin(oldBins: Array<string>) {
-  const bins = await getCargoBins();
-
-  for (const bin of oldBins) {
-    bins.delete(bin);
-  }
+  const binsToRemove = new Set<string>(oldBins);
 
   const dir = await fs.promises.opendir(path.join(CARGO_HOME, "bin"));
   for await (const dirent of dir) {
-    if (dirent.isFile() && !bins.has(dirent.name)) {
+    if (dirent.isFile() && binsToRemove.has(dirent.name)) {
       await rm(dir.path, dirent);
     }
   }


### PR DESCRIPTION
The current implementation of [`getCargoBins`](https://github.com/clechasseur/rust-cache/blob/f51f967e158417aafa338a1e46ab22095f07aa01/src/cleanup.ts#L78-L90) to check which binary is installed in `$CARGO_HOME/bin` checks the content of `$CARGO-HOME/.crates2.json` to determine which binary is preinstalled. When saving cache, all binaries not found in that file are removed to avoid caching them.

This means, however, that anything installed via a mean other than `cargo install` (like for example via [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall)) won't be cached.

This PR changes the logic: now, when restoring cache, the `$CARGO_HOME/bin` directory is scanned and all files there are kept in the action state. When saving the cache post-install, all binaries that were in the directory at the beginning are removed; all others are cached. This allows the use of something like `cargo-binstall` or [`taiki-e/install-action`](https://github.com/taiki-e/install-action), while still benefiting from caching.

I've also added a new workflow to test with `cargo-binstall`.

Let me know if there's something I should update as well.