### PR TITLE
docs: Update checkout action version to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ sensible defaults.
 ## Example usage
 
 ```yaml
-- uses: actions/checkout@v5
+- uses: actions/checkout@v6
 
 # selecting a toolchain either by action or manual `rustup` calls should happen
 # before the plugin, as the cache uses the current rustc version as its cache key


### PR DESCRIPTION
Just a minor correction to help people copying the example outright stay on the latest version